### PR TITLE
Temporarily revert CNAME changes

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-getstarted.nj.gov

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   "scripts": {
     "start": "SKIP_PREFLIGHT_CHECK=true react-scripts start",
     "build": "SKIP_PREFLIGHT_CHECK=true react-scripts build",
-    "predeploy": "PUBLIC_URL=https://newjersey.github.io/dol-eligibility-tool/labor yarn run build",
-    "deploy": "gh-pages -d build -e labor",
+    "predeploy": "PUBLIC_URL=https://newjersey.github.io/dol-eligibility-tool yarn run build",
+    "deploy": "gh-pages -d build",
     "test": "jest --testPathIgnorePatterns 'backend/.*'",
     "eject": "react-scripts eject",
     "lint:check": "eslint '**/*.{js,jsx,ts,tsx}' --max-warnings=0 && prettier --check .",


### PR DESCRIPTION
This is just temporary, so that we can access the site again for standup.

Feel free to revert this PR @rossdakin when you're ready to get the domain running.

See: https://newjersey.github.io/dol-eligibility-tool