### PR TITLE
August Updates

### DIFF
--- a/public/form.yml
+++ b/public/form.yml
@@ -658,8 +658,7 @@ definitions:
       additionalKeys: 'benefits,job-protections'
       options:
         - name:
-            en: "I can't work, or my hours are reduced, because I need to care for my children due to COVID-19-
-              related school or child care closures, including mandatory remote learning."
+            en: "I can't work, or my hours are reduced, because I need to care for my children due to COVID-19-related school or child care closures, including mandatory remote learning."
             es: 'No puedo trabajar, o mis horas se reducen, porque necesito cuidar a mis hijos debido al cierre de escuelas o guarderías relacionadas con COVID-19, incluido el aprendizaje remoto obligatorio.'
           id: situation-1
           benefits: 'ESL-NJ,UA,FEC-FMLA-FED'

--- a/public/form.yml
+++ b/public/form.yml
@@ -658,8 +658,9 @@ definitions:
       additionalKeys: 'benefits,job-protections'
       options:
         - name:
-            en: "I can't work, or my hours are reduced, because I need to care for children due to COVID-19."
-            es: 'No puedo trabajar, o mis horas se reducen, porque necesito cuidar a los niños debido a COVID-19.'
+            en: "I can't work, or my hours are reduced, because I need to care for my children due to COVID-19-
+              related school or child care closures, including mandatory remote learning."
+            es: 'No puedo trabajar, o mis horas se reducen, porque necesito cuidar a mis hijos debido al cierre de escuelas o guarderías relacionadas con COVID-19, incluido el aprendizaje remoto obligatorio.'
           id: situation-1
           benefits: 'ESL-NJ,UA,FEC-FMLA-FED'
           job-protections: 'FMLA-FED,FLA-NJ'

--- a/public/form.yml
+++ b/public/form.yml
@@ -324,17 +324,17 @@ sections:
 
         **Suggested next steps:**
 
-        1. Get more information [here](https://myunemployment.nj.gov/labor/assets/PDFs/CovidDiscrimination_FINAL.pdf)
-        2. Talk to your employer about your right to job protection
-        3. If the employer doesn't comply, [file a complaint](https://www.nj.gov/labor/wagehour/complnt/filing_wage_claim.html)
+        1. Get more information [here](https://www.nj.gov/labor/worker-protections/covid_discrimination.shtml).
+        2. Talk to your employer about your right to job protection; you can refer them to the information [here](https://www.nj.gov/labor/worker-protections/covid_discrimination.shtml).
+        3. If the employer doesn’t comply, file a [complaint](https://www.nj.gov/labor/wagehour/complnt/filing_wage_claim.html) (also known as wage claim) with NJDOL.
       es: |-
         Los empleadores tienen prohibido despedir o castigar a un empleado que solicita tiempo libre o se ausenta del trabajo en base a la determinación de un profesional médico de que el empleado tiene, o es probable que tenga, COVID-19. La ley solo se aplica durante la pandemia COVID-19 y la emergencia de salud pública relacionada y la emergencia estatal.
 
         ** Próximos pasos sugeridos: **
 
-        1. Obtenga más información [aquí](https://myunemployment.nj.gov/labor/assets/PDFs/CovidDiscrimination_FINAL.pdf)
-        2. Hable con su empleador sobre su derecho a la protección laboral
-        3. Si el empleador no cumple, [presentar una queja](https://www.nj.gov/labor/wagehour/complnt/filing_wage_claim.html)
+        1. Obtenga más información [aquí](https://www.nj.gov/labor/worker-protections/covid_discrimination.shtml).
+        2. Hable con su empleador sobre su derecho a la protección laboral; puedes referirlos a la información [aquí](https://www.nj.gov/labor/worker-protections/covid_discrimination.shtml).
+        3. Si el empleador no cumple, presente una [queja](https://www.nj.gov/labor/wagehour/complnt/filing_wage_claim.html) (también conocida como reclamo salarial) ante NJDOL.
   FMLA-FED:
     title:
       en: Federal Family and Medical Leave Act (FMLA)

--- a/public/form.yml
+++ b/public/form.yml
@@ -771,18 +771,17 @@ definitions:
             instructions:
               en: |-
                 Based on the information you've provided, you may be eligible for protection or financial aid from these program(s):
-
-                Note: All protections are **unpaid leave**. We have listed these programs in suggested priority order for your convenience.
               es: |-
                 Según la información que proporcionó, puede ser elegible para recibir protección o ayuda financiera de estos programas:
-
-                Nota: Todas las protecciones son ** licencia no remunerada **. Hemos enumerado estos programas en orden de prioridad sugerido para su conveniencia.
           - id: terminal-eligibility-benefits
             type: sections
             sections:
               name:
                 en: Benefits
                 es: Beneficios
+              instructions:
+                en: We have listed these programs in suggested priority order for your convenience.
+                es: Hemos enumerado estos programas en el orden de prioridad sugerido para su conveniencia.
               id: benefits
               color: '#F6F7F9'
           - id: terminal-eligibility-job-protections
@@ -791,6 +790,9 @@ definitions:
               name:
                 en: Job Protections
                 es: Protecciones laborales
+              instructions:
+                en: 'Note: All protections are unpaid.'
+                es: 'Nota: Todas las protecciones no se pagan.'
               id: job-protections
               color: '#ECEEF1'
           - id: faq-terminal-not-eligible

--- a/public/form.yml
+++ b/public/form.yml
@@ -680,7 +680,7 @@ definitions:
             color: '#4FAB5B'
         - name:
             en: |-
-              I can’t work because I’m advised by a doctor or public health authority to quarantine.
+              I can't work because I'm advised by a doctor or public health authority to quarantine.
             es: |-
               No puedo trabajar porque un médico o una autoridad de salud pública me aconsejaron ponerme en cuarentena.
           id: situation-3

--- a/public/form.yml
+++ b/public/form.yml
@@ -315,25 +315,26 @@ sections:
         2. Hable con su empleador sobre su derecho a utilizar este permiso
   A3848:
     title:
-      en: A3848 Legislation
-      es: A3848 Legislación
+      en: Protection against COVID-19 related discrimination at work
+      es: Protección contra la discriminación laboral relacionada con COVID-19
     content:
       en: |-
-        You may be eligible for special job protection, due to COVID-19. Your employer cannot terminate or refuse to reinstate your employment status if you have, or are likely to have, an infectious disease which requires you to miss time at work.
+        Employers are prohibited from firing or otherwise punishing an employee who requests time off or 
+        takes time off from work based on a medical professional’s determination that the employee has, or is likely to have, COVID-19. The law only applies during the COVID-19 Pandemic and related Public Health Emergency and State Emergency.
 
         **Suggested next steps:**
 
-        1. Get more information [here](https://www.njleg.state.nj.us/2020/Bills/A4000/3848_I1.HTM)
+        1. Get more information [here](https://myunemployment.nj.gov/labor/assets/PDFs/CovidDiscrimination_FINAL.pdf)
         2. Talk to your employer about your right to job protection
-        3. If they don't comply, [file a wage claim](https://www.nj.gov/labor/wagehour/complnt/filing_wage_claim.html)
+        3. If the employer doesn't comply, [file a complaint](https://www.nj.gov/labor/wagehour/complnt/filing_wage_claim.html)
       es: |-
-        Puede ser elegible para protección laboral especial, debido a COVID-19. Su empleador no puede rescindir o negarse a restablecer su estado de empleo si tiene, o es probable que tenga, una enfermedad infecciosa que requiera que pierda tiempo en el trabajo.
+        Los empleadores tienen prohibido despedir o castigar a un empleado que solicita tiempo libre o se ausenta del trabajo en base a la determinación de un profesional médico de que el empleado tiene, o es probable que tenga, COVID-19. La ley solo se aplica durante la pandemia COVID-19 y la emergencia de salud pública relacionada y la emergencia estatal.
 
         ** Próximos pasos sugeridos: **
 
-        1. Obtenga más información [aquí](https://www.njleg.state.nj.us/2020/Bills/A4000/3848_I1.HTM)
+        1. Obtenga más información [aquí](https://myunemployment.nj.gov/labor/assets/PDFs/CovidDiscrimination_FINAL.pdf)
         2. Hable con su empleador sobre su derecho a la protección laboral
-        3. Si no cumplen, [presente un reclamo salarial](https://www.nj.gov/labor/wagehour/complnt/filing_wage_claim.html)
+        3. Si el empleador no cumple, [presentar una queja](https://www.nj.gov/labor/wagehour/complnt/filing_wage_claim.html)
   FMLA-FED:
     title:
       en: Federal Family and Medical Leave Act (FMLA)
@@ -403,7 +404,7 @@ pages:
 
         ###### Job Protections
 
-        - A3848 Legislation
+        - Protection against COVID-19 related discrimination at work
         - Federal Family and Medical Leave Act (FMLA)
         - NJ Family Leave Act (FLA)
 
@@ -678,9 +679,9 @@ definitions:
             color: '#4FAB5B'
         - name:
             en: |-
-              I can't work, or my hours are reduced, because I'm advised to by a doctor or public health authority to quarantine.
+              I can’t work because I’m advised by a doctor or public health authority to quarantine.
             es: |-
-              No puedo trabajar, o mis horas se reducen, porque un médico o una autoridad de salud pública me lo recomiendan para poner en cuarentena.
+              No puedo trabajar porque un médico o una autoridad de salud pública me aconsejaron ponerme en cuarentena.
           id: situation-3
           benefits: 'UA,ESL-NJ,TDI-NJ,EPSL-FED'
           job-protections: 'A3848,FMLA-FED'

--- a/public/form.yml
+++ b/public/form.yml
@@ -781,8 +781,8 @@ definitions:
                 en: Benefits
                 es: Beneficios
               instructions:
-                en: We have listed these programs in suggested priority order for your convenience.
-                es: Hemos enumerado estos programas en el orden de prioridad sugerido para su conveniencia.
+                en: 'Note: We have listed these programs in suggested priority order for your convenience.'
+                es: 'Nota: Hemos enumerado estos programas en el orden de prioridad sugerido para su conveniencia.'
               id: benefits
               color: '#F6F7F9'
           - id: terminal-eligibility-job-protections
@@ -792,8 +792,8 @@ definitions:
                 en: Job Protections
                 es: Protecciones laborales
               instructions:
-                en: 'Note: All protections are unpaid.'
-                es: 'Nota: Todas las protecciones no se pagan.'
+                en: 'Note: All protections are unpaid, but the timing could overlap with benefits listed above.'
+                es: 'Nota: Todas las protecciones no se pagan, pero el tiempo podría superponerse con los beneficios enumerados anteriormente.'
               id: job-protections
               color: '#ECEEF1'
           - id: faq-terminal-not-eligible

--- a/src/components/form-components/Section.tsx
+++ b/src/components/form-components/Section.tsx
@@ -51,10 +51,14 @@ const Section: React.FC<Props> = (props) => {
       <Heading level={3} margin="none">
         {translateCopy(question.sections.name)}
       </Heading>
+      {question.sections.instructions && (
+        <Markdown margin={{ top: 'small' }} size="small">
+          {translateCopy(question.sections.instructions)}
+        </Markdown>
+      )}
       {sectionGroup.map(({ section, options }, index) => {
         const icons = options.filter((o) => !!o.icon).map((o) => o.icon!)
         icons.sort((i1, i2) => i1.label.localeCompare(i2.label))
-
         return (
           <Box
             background="#FFFFFF"

--- a/src/form.schema.json
+++ b/src/form.schema.json
@@ -93,6 +93,10 @@
               "$ref": "#/definitions/copy",
               "description": "The name of this group of sections"
             },
+            "instructions": {
+              "$ref": "#/definitions/copy",
+              "description": "Optional instructions for this section."
+            },
             "id": {
               "type": "string",
               "description": "If specified, a list of sections to render is pulled from the current form values using the provided id."

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -40,6 +40,7 @@ export interface Question {
 
 export interface Sections {
   name: Copy
+  instructions?: Copy
   id?: string
   include?: string[]
   color: string


### PR DESCRIPTION
# August Updates
This PR adds some updates requested by NJ:

## Move section notices to directly under section titles
The notice, that was previously above both sections, has been separated and moved under "Benefits" and "Job Protections" titles.
<img width="789" alt="Screen Shot 2020-08-25 at 11 48 39 PM" src="https://user-images.githubusercontent.com/31225471/91270540-a40bc200-e72d-11ea-83ea-c7ab0d0c240e.png">

## Update A3848 Language
The language for A3848 has been updated wherever requested.

**In the introduction:**
<img width="451" alt="Screen Shot 2020-08-24 at 10 45 00 PM" src="https://user-images.githubusercontent.com/31225471/91128574-4c058a80-e65d-11ea-96b3-4e3751aa1b3b.png">

**As option C:**
<img width="697" alt="Screen Shot 2020-08-24 at 10 45 24 PM" src="https://user-images.githubusercontent.com/31225471/91128584-5031a800-e65d-11ea-8f00-639049d4d4d6.png">

**As a final section:**
<img width="707" alt="Screen Shot 2020-08-25 at 11 42 57 PM" src="https://user-images.githubusercontent.com/31225471/91270065-ea145600-e72c-11ea-84e2-d90592453a91.png">

**Links are updated:**
Links in the final section have been updated to Eric's suggested links.
![updated-links](https://user-images.githubusercontent.com/31225471/91270073-f0a2cd80-e72c-11ea-8ea8-587b1fae6426.gif)

## Minor Copy Changes for Back-To-School
The copy for the back to school option A) has been updated to:
<img width="730" alt="Screen Shot 2020-08-26 at 4 06 33 PM" src="https://user-images.githubusercontent.com/31225471/91365507-263fc900-e7b6-11ea-8bf4-66ed9d83e189.png">


