### PR TITLE
Revert "Hide language sidebar for now until we have validated Spanish translations"

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,29 +2,28 @@ import React, { useContext } from 'react'
 import { Button } from './helper-components'
 import { Card } from './helper-components'
 import { Box, Text, Image, ResponsiveContext, Heading, Paragraph } from 'grommet'
-// import { LanguageContext } from '../contexts/language'
+import { LanguageContext } from '../contexts/language'
 import { FormContext } from '../contexts/form'
 import { range } from 'lodash'
 import { StyledSelect } from './helper-components/StyledSelect'
 import { FormTrash } from 'grommet-icons'
-// import amplitude from 'amplitude-js'
+import amplitude from 'amplitude-js'
 
 interface Props {
   pages: string[]
 }
 
-// NOTE: bring back once we have Spanish translations.
-// const languages = [
-//   { title: 'English', value: 'en' },
-//   // NJ isn't using Chinese language translations
-//   // { title: '中文', value: 'zh' },
-//   { title: 'Español', value: 'es' },
-// ]
+const languages = [
+  { title: 'English', value: 'en' },
+  // NJ isn't using Chinese language translations
+  // { title: '中文', value: 'zh' },
+  { title: 'Español', value: 'es' },
+]
 
 const Sidebar: React.FC<Props> = (props) => {
   const { pages } = props
   const { values, clearForm, translateByID, form, pageIndex, setPage, completion } = useContext(FormContext)
-  // const { language, setLanguage } = useContext(LanguageContext)
+  const { language, setLanguage } = useContext(LanguageContext)
   const size = useContext(ResponsiveContext)
 
   const currentPage = pages[pageIndex]
@@ -37,19 +36,19 @@ const Sidebar: React.FC<Props> = (props) => {
     return range(0, i).every((index) => completion[index])
   }
 
-  // const onChangeLanguage = ({ value }: any) => {
-  //   console.log('[Google Analytics] sending event: Change Language')
-  //   gtag('event', 'Change Language', {
-  //     prevLanguage: language,
-  //     newLanguage: value,
-  //   })
-  //   amplitude.getInstance().logEvent('Change Language', {
-  //     prevLanguage: language,
-  //     newLanguage: value,
-  //   })
+  const onChangeLanguage = ({ value }: any) => {
+    console.log('[Google Analytics] sending event: Change Language')
+    gtag('event', 'Change Language', {
+      prevLanguage: language,
+      newLanguage: value,
+    })
+    amplitude.getInstance().logEvent('Change Language', {
+      prevLanguage: language,
+      newLanguage: value,
+    })
 
-  //   setLanguage(value)
-  // }
+    setLanguage(value)
+  }
 
   return (
     <Box
@@ -66,8 +65,7 @@ const Sidebar: React.FC<Props> = (props) => {
           </Box>
         )}
         <Box flex={{ grow: 1 }} margin={{ left: size === 'medium' ? '24px' : 'none' }}>
-          {/* NOTE: bring this back once we have validated Spanish translations in. */}
-          {/* <Box>
+          <Box>
             <Heading level={4} margin="none">
               {translateByID('language')}
             </Heading>
@@ -80,7 +78,7 @@ const Sidebar: React.FC<Props> = (props) => {
               value={language}
               onChange={onChangeLanguage}
             />
-          </Box> */}
+          </Box>
           <Box margin={{ top: '24px' }}>
             <Box direction="row" justify="between">
               <Heading level={4} margin="none">


### PR DESCRIPTION
This reverts commit 438442585b0bbda3aa3700503f4f9dbf6747c56a.

The goal is to re-enable the sidebar dropdown which allows users to choose which language the tool will display.