### PR TITLE
Use english for nonlocalized strings

### DIFF
--- a/src/contexts/form.tsx
+++ b/src/contexts/form.tsx
@@ -184,7 +184,14 @@ export const FormProvider: React.FC = (props) => {
         return undefined
       }
 
-      let text = copy[language]
+      let text
+      if (language in copy) {
+        text = copy[language]
+      } else if ('en' in copy) {
+        text = copy['en']
+      } else {
+        text = 'UNKNOWN STRING'
+      }
 
       // Apply templating variables by looking for `{{VARIABLE_NAME}}` fields.
       // The value is evaluated as the first truthy value of:


### PR DESCRIPTION
See https://usdrcovid19.slack.com/archives/C01874U5PDH/p1600717907009800?thread_ts=1600369391.043000&cid=C01874U5PDH

When getting a localized version of a string, if there's no localization in the desired language, use English instead.  If English is not available, show an error message (in English.)