### PR TITLE
Add 3 new benefits (UI, FLDU, DDU) and 3 new Q3 options

### DIFF
--- a/public/form.yml
+++ b/public/form.yml
@@ -409,6 +409,29 @@ sections:
         ** Próximos pasos sugeridos: **
 
         1. Obtenga más información y aprenda cómo postularse [aquí](https://myleavebenefits.nj.gov/unemployed).
+  UI-NJ:
+    title:
+      en: Unemployment Insurance (UI)
+      es: Seguro de desempleo (UI)
+    content:
+      en: |-
+        You may be eligible for regular Unemployment Insurance benefits. In most cases, you cannot collect Unemployment Insurance (UI) benefits if you refuse [suitable work](https://www.nj.gov/labor/worker-protections/returntowork.shtml). Exceptions could occur where an individual quits or refuses work because the work poses a high degree of risk to health and safety. NJDOL examines cases on an individual basis, and makes eligibility determinations in accordance with the law.
+
+        **Suggested next steps:**
+
+        1. Learn more about returning to work amid COVID-19 [here](https://www.nj.gov/labor/worker-protections/returntowork.shtml).
+        2. Learn [how to apply](https://myunemployment.nj.gov/labor/myunemployment/before/about/howtoapply/) for unemployment.
+        3. Create an account at [myunemployment.nj.gov](https://myunemployment.nj.gov/labor/myunemployment/before/createaccount/index.shtml).
+        4. File an [application](https://myunemployment.nj.gov/) (online preferred).
+      es: |-
+        Puede ser elegible para los beneficios regulares del seguro de desempleo. En la mayoría de los casos, no puede cobrar los beneficios del seguro de desempleo (UI) si se niega a [trabajo adecuado](https://www.nj.gov/labor/worker-protections/returntowork.shtml). Pueden ocurrir excepciones cuando una persona renuncia o se niega a trabajar porque el trabajo presenta un alto grado de riesgo para la salud y la seguridad. NJDOL examina los casos de forma individual y determina la elegibilidad de acuerdo con la ley.
+
+        ** Próximos pasos sugeridos: **
+
+        1. Obtenga más información sobre cómo regresar al trabajo en medio de COVID-19 [aquí](https://www.nj.gov/labor/worker-protections/returntowork.shtml)
+        2. Aprenda [cómo solicitar](https://myunemployment.nj.gov/labor/myunemployment/before/about/howtoapply/) para el desempleo.
+        3. Cree una cuenta en [myunemployment.nj.gov] (https://myunemployment.nj.gov/labor/myunemployment/before/createaccount/index.shtml).
+        4. Presente una [solicitud] (https://myunemployment.nj.gov/) (preferiblemente en línea).
 pages:
   - title:
       en: Introduction
@@ -810,7 +833,7 @@ definitions:
             en: 'My workplace is unsafe, my employer refuses to follow health and safety guidelines, and I refuse to work.'
             es: 'Mi lugar de trabajo no es seguro, mi empleador se niega a seguir las pautas de salud y seguridad y yo me niego a trabajar.'
           id: situation-12
-          benefits: UA
+          benefits: UI-NJ
           icon:
             label: K
             color: '#FFB6C1'

--- a/public/form.yml
+++ b/public/form.yml
@@ -3,7 +3,7 @@ title:
   es: NJDOL COVID-19 Benefits Eligibility Tool
 description:
   en: Determine what benefits you are eligible in the state of New Jersey.
-  es: Determine qué beneficios es elegible en el estado de Nueva Jersey.
+  es: Determine qué beneficios es elegible en el estado de New Jersey.
 seal: NJDOL_logo_web_560x560.png
 variables:
   STATE_CODE: NJ
@@ -49,7 +49,7 @@ instructions:
       Una vez que se hayan verificado todas las secciones, seleccione 'Enviar' para completar el llenado de su reclamo. Su reclamo no se archivará a menos que haga clic en 'Enviar' a continuación.
   demo-warning:
     en: This is a demo of the New Jersey benefits questionnaire.
-    es: Esta es una demostración del cuestionario de beneficios de Nueva Jersey.
+    es: Esta es una demostración del cuestionario de beneficios de New Jersey.
   back:
     en: Go Back
     es: Regresa
@@ -143,7 +143,7 @@ sections:
   ESL-NJ:
     title:
       en: New Jersey Earned Sick Leave (ESL)
-      es: Licencia por enfermedad ganada de Nueva Jersey (ESL)
+      es: Licencia por enfermedad ganada de New Jersey (ESL)
     content:
       en: |-
         You may be eligible for sick leave from your employer through New Jersey's Earned Sick Leave. The New Jersey Earned Sick Leave Law allows employees to accrue 1 hour of earned sick leave for every 30 hours worked, up to 40 hours each year.
@@ -154,7 +154,7 @@ sections:
         2. Talk to your employer about your right to utilize this leave
         3. If they don't comply, file a [wage claim](https://www.nj.gov/labor/wagehour/complnt/filing_wage_claim.html) (online preferred)
       es: |-
-        Puede ser elegible para licencia por enfermedad de su empleador a través de la licencia por enfermedad ganada de Nueva Jersey. La Ley de licencia por enfermedad por enfermedad de Nueva Jersey permite a los empleados acumular 1 hora de licencia por enfermedad por cada 30 horas trabajadas, hasta 40 horas cada año.
+        Puede ser elegible para licencia por enfermedad de su empleador a través de la licencia por enfermedad ganada de New Jersey. La Ley de licencia por enfermedad por enfermedad de New Jersey permite a los empleados acumular 1 hora de licencia por enfermedad por cada 30 horas trabajadas, hasta 40 horas cada año.
 
         ** Próximos pasos sugeridos: **
 
@@ -164,7 +164,7 @@ sections:
   FLI-NJ:
     title:
       en: New Jersey Family Leave Insurance (FLI)
-      es: Seguro de licencia familiar de Nueva Jersey (FLI)
+      es: Seguro de licencia familiar de New Jersey (FLI)
     content:
       en: |-
         You may be eligible for Family Leave Insurance. Family Leave Insurance provides New Jersey workers cash benefits for up to 12 weeks to provide care for a seriously ill or injured family member.
@@ -175,7 +175,7 @@ sections:
         2. Create an account
         3. File an [application](https://myleavebenefits.nj.gov/labor/myleavebenefits/worker/fli/) (online preferred)
       es: |-
-        Puede ser elegible para el seguro de licencia familiar. El seguro de licencia familiar brinda a los trabajadores de Nueva Jersey beneficios en efectivo por hasta 12 semanas para brindar atención a un familiar gravemente enfermo o lesionado.
+        Puede ser elegible para el seguro de licencia familiar. El seguro de licencia familiar brinda a los trabajadores de New Jersey beneficios en efectivo por hasta 12 semanas para brindar atención a un familiar gravemente enfermo o lesionado.
 
         ** Próximos pasos sugeridos: **
 
@@ -185,7 +185,7 @@ sections:
   TDI-NJ:
     title:
       en: New Jersey Temporary Disability Insurance (TDI)
-      es: Seguro de discapacidad temporal de Nueva Jersey (TDI)
+      es: Seguro de discapacidad temporal de New Jersey (TDI)
     content:
       en: |-
         You may be eligible for Temporary Disability Insurance. Temporary Disability Insurance provides cash benefits to (1) New Jersey workers who suffer an illness, injury, or other disability that prevents them from working, and wasn’t caused by their job, and (2) expectant mothers who need to stop working before giving birth and for their recovery.
@@ -196,7 +196,7 @@ sections:
         2. Create an account
         3. File an [application](https://myleavebenefits.nj.gov/labor/myleavebenefits/worker/tdi/) (online preferred)
       es: |-
-        Puede ser elegible para el seguro por discapacidad temporal. El seguro de discapacidad temporal proporciona beneficios en efectivo a (1) los trabajadores de Nueva Jersey que sufren una enfermedad, lesión u otra discapacidad que les impide trabajar y no fue causada por su trabajo, y (2) las mujeres embarazadas que necesitan dejar de trabajar antes dar a luz y para su recuperación.
+        Puede ser elegible para el seguro por discapacidad temporal. El seguro de discapacidad temporal proporciona beneficios en efectivo a (1) los trabajadores de New Jersey que sufren una enfermedad, lesión u otra discapacidad que les impide trabajar y no fue causada por su trabajo, y (2) las mujeres embarazadas que necesitan dejar de trabajar antes dar a luz y para su recuperación.
 
         ** Próximos pasos sugeridos: **
 
@@ -357,7 +357,7 @@ sections:
   FLA-NJ:
     title:
       en: New Jersey Family Leave Act (NJFLA)
-      es: Ley de licencia familiar de Nueva Jersey (NJFLA)
+      es: Ley de licencia familiar de New Jersey (NJFLA)
     content:
       en: |-
         You may be eligible for unpaid Family Leave from your employer under the New Jersey Family Leave Act. If your employer is covered under the NJFLA, and you are an eligible employee, then you are generally entitled to up to 12 weeks of job-protected leave to care for a loved one in a two-year period. This includes leave to care for your child if their school or place of care is closed by order of a public official due to COVID-19.
@@ -368,7 +368,7 @@ sections:
         2. Talk to your employer about your job protection situation
         3. If they do not comply, [file a complaint](https://www.nj.gov/oag/dcr/filing.html)
       es: |-
-        Puede ser elegible para un Permiso Familiar no remunerado de su empleador según la Ley de Permiso Familiar de Nueva Jersey. Si su empleador está cubierto por la NJFLA y usted es un empleado elegible, entonces generalmente tiene derecho a hasta 12 semanas de licencia con protección laboral para cuidar a un ser querido en un período de dos años. Esto incluye permiso para cuidar a su hijo si su escuela o lugar de cuidado está cerrado por orden de un funcionario público debido a COVID-19.
+        Puede ser elegible para un Permiso Familiar no remunerado de su empleador según la Ley de Permiso Familiar de New Jersey. Si su empleador está cubierto por la NJFLA y usted es un empleado elegible, entonces generalmente tiene derecho a hasta 12 semanas de licencia con protección laboral para cuidar a un ser querido en un período de dos años. Esto incluye permiso para cuidar a su hijo si su escuela o lugar de cuidado está cerrado por orden de un funcionario público debido a COVID-19.
 
         ** Próximos pasos sugeridos: **
 
@@ -473,7 +473,7 @@ pages:
 
         The information you share for purposes of this screening tool will be anonymous and may be shared with New Jersey State agencies to improve access to benefits and programs.
       es: |-
-        La pandemia del COVID-19 está causando una alteración extraordinaria en la vida de los trabajadores de Nueva Jersey. El Department of Labor and Workforce Development de New Jersey (NJDOL) quiere facilitarle la comprensión de los programas de beneficios que están disponibles para ayudar a estabilizar su situación económica durante estos momentos difíciles.
+        La pandemia del COVID-19 está causando una alteración extraordinaria en la vida de los trabajadores de New Jersey. El Department of Labor and Workforce Development de New Jersey (NJDOL) quiere facilitarle la comprensión de los programas de beneficios que están disponibles para ayudar a estabilizar su situación económica durante estos momentos difíciles.
 
         Esta es una versión beta de esta herramienta. Lo actualizaremos periódicamente a medida que estén disponibles nuevos beneficios federales, estatales y locales. Se revisa su posible elegibilidad para los programas a continuación según la información que proporcione.
 
@@ -481,7 +481,7 @@ pages:
 
         ###### Beneficios
 
-        - Licencia por enfermedad pagada de Nueva Jersey (ESL)
+        - Licencia por enfermedad pagada de New Jersey (ESL)
         - Seguro de licencia familiar de NJ (FLI)
         - Seguro de incapacidad temporal de NJ (TDI)
         - Asistencia de desempleo
@@ -495,7 +495,7 @@ pages:
 
         - Protección contra la discriminación laboral relacionada con COVID-19
         - Ley Federal de Licencia Médica y Familiar (FMLA)
-        - Ley de licencia familiar de Nueva Jersey (NJFLA)
+        - Ley de licencia familiar de New Jersey (NJFLA)
 
         #### Términos de servicio
 
@@ -503,7 +503,7 @@ pages:
 
         Esta herramienta de evaluación proporcionará los siguientes pasos sugeridos que pueden incluir solicitar beneficios fuera de este sitio web, pero no puede garantizar la elegibilidad y no reserva ningún beneficio ni un lugar en ninguna fila de solicitudes. La organización o agencia administradora determinará todos los requisitos de elegibilidad una vez que envíe una solicitud y / u otros documentos pertinentes a esa organización o agencia para el programa respectivo.
 
-        La información que comparta para los fines de esta herramienta de evaluación será anónima y puede compartirse con las agencias estatales de Nueva Jersey para mejorar el acceso a los beneficios y programas.
+        La información que comparta para los fines de esta herramienta de evaluación será anónima y puede compartirse con las agencias estatales de New Jersey para mejorar el acceso a los beneficios y programas.
     questions:
       - name:
           en: Agreement
@@ -528,7 +528,7 @@ pages:
     questions:
       - name:
           en: Are you currently employed in New Jersey?
-          es: ¿Actualmente trabaja en Nueva Jersey?
+          es: ¿Actualmente trabaja en New Jersey?
         id: employed_in_new_jersey
         required: true
         type: single-select
@@ -539,7 +539,7 @@ pages:
             id: yes
           - name:
               en: 'No. I was laid off, furloughed, or am otherwise not receiving pay for my job in New Jersey.'
-              es: 'No. Fui despedido, suspendido o de lo contrario no recibo paga por mi trabajo en Nueva Jersey.'
+              es: 'No. Fui despedido, suspendido o de lo contrario no recibo paga por mi trabajo en New Jersey.'
             id: laid-off-in-new-jersey
           - name:
               en: 'No, I work in another state'
@@ -584,7 +584,7 @@ pages:
                 self-employed-by-independent-contractor:
                   - name:
                       en: Have you already applied for unemployment insurance through the state of New Jersey?
-                      es: ¿Ya solicitó el seguro de desempleo en el estado de Nueva Jersey?
+                      es: ¿Ya solicitó el seguro de desempleo en el estado de New Jersey?
                     id: already-applied
                     type: single-select
                     required: true
@@ -719,7 +719,7 @@ pages:
 
                   *You may also qualify for federal benefits under the [CARES Act.](https://www.dol.gov/coronavirus/unemployment-insurance)*
                 es: |-
-                  ** La herramienta de elegibilidad de beneficios COVID-19 del estado de Nueva Jersey está diseñada para ayudar a las personas que trabajan en Nueva Jersey a identificar programas de beneficios para los que pueden ser elegibles.**
+                  ** La herramienta de elegibilidad de beneficios COVID-19 del estado de New Jersey está diseñada para ayudar a las personas que trabajan en New Jersey a identificar programas de beneficios para los que pueden ser elegibles.**
 
                   Verifique con el estado donde está / estuvo empleado anteriormente para ver si califica para los beneficios allí.
 

--- a/public/form.yml
+++ b/public/form.yml
@@ -372,7 +372,7 @@ sections:
 
         ** Próximos pasos sugeridos: **
 
-        1. Obtenga más información: [NJ Family Leave Act](https://www.nj.gov/oag/dcr/downloads/fact-FLA.pdf)
+        1. Obtenga más información: [NJ Family Leave Act](https://www.nj.gov/oag/dcr/downloads/Fact_FLA_ESP.pdf)
         2. Hable con su empleador sobre su situación de protección laboral
         3. Si no cumplen, [presente una queja](https://www.nj.gov/oag/dcr/filing.html)
   DDU-NJ:

--- a/public/form.yml
+++ b/public/form.yml
@@ -378,16 +378,16 @@ sections:
   DDU-NJ:
     title:
       en: New Jersey Disability During Unemployment (NJDDU)
-      es: Discapacidad de Nueva Jersey durante el desempleo (NJDDU)
+      es: Seguro de Incapacidad de New Jersey Durante el Desempleo (NJDDU)
     content:
       en: |-
-        If your medical provider certifies you are unable to work due to your own non-work-related medical condition, including pregnancy and delivery, more than 14 days after your last day of work in covered employment, you may be eligible for Disability During Unemployment (DDU) benefits. This is a combination of the Unemployment and Temporary Disability Insurance programs.
+        If your medical provider certifies you are unable to work due to your own non-work-related medical condition, including pregnancy and delivery, more than 14 days after your last day of work, you may be eligible for Disability During Unemployment (DDU) benefits. This is a combination of the Unemployment and Temporary Disability Insurance programs.
 
         **Suggested next steps:**
 
         1. Get more information and learn how to apply [here](https://myleavebenefits.nj.gov/unemployed).
       es: |-
-        Si su proveedor médico certifica que no puede trabajar debido a su propia afección médica no relacionada con el trabajo, incluidos el embarazo y el parto, más de 14 días después de su último día de trabajo en un empleo cubierto, es posible que sea elegible para la discapacidad durante el desempleo (DDU) beneficios. Esta es una combinación de los programas de seguro de desempleo y por discapacidad temporal.
+        Si su proveedor médico certifica que no puede trabajar debido a su propia condición médica no relacionada con el trabajo, incluidos el embarazo y el parto, más de 14 días después de su último día de trabajo, es posible que sea elegible para los beneficios de Incapacidad Durante el Desempleo (DDU). DDU es una combinación de los programas de Seguro de Desempleo y por Incapacidad Temporal.
 
         ** Próximos pasos sugeridos: **
 
@@ -395,16 +395,16 @@ sections:
   FLDU-NJ:
     title:
       en: New Jersey Family Leave During Unemployment (NJFLDU)
-      es: Permiso familiar de Nueva Jersey durante el desempleo (NJFLDU)
+      es: Licencia Familiar de New Jersey Durante el Desempleo (NJFLDU)
     content:
       en: |-
-        If you need to bond with a new child or care for an ill or injured loved one more than 14 days after your last day of work in covered employment, and are not on an employer-approved leave of absence, you may be eligible for Family Leave During Unemployment (FLDU) benefits. This is a combination of the Unemployment and Family Leave Insurance programs.
+        If you need to bond with a new child or care for an ill or injured loved one more than 14 days after your last day of work, and are not on an employer-approved leave of absence, you may be eligible for Family Leave During Unemployment (FLDU) benefits. This is a combination of the Unemployment and Family Leave Insurance programs.
 
         **Suggested next steps:**
 
         1. Get more information and learn how to apply [here](https://myleavebenefits.nj.gov/unemployed).
       es: |-
-        Si necesita vincularse con un nuevo hijo o cuidar a un ser querido enfermo o lesionado más de 14 días después de su último día de trabajo en un empleo cubierto, y no está en una licencia de ausencia aprobada por el empleador, puede ser elegible para Beneficios de licencia durante el desempleo (FLDU). Esta es una combinación de los programas de seguro por desempleo y permiso familiar.
+        Si necesita vincularse con un hijo nuevo o cuidar a un ser querido enfermo o lesionado más de 14 días después de su último día de trabajo, y no está en una licencia de ausencia aprobada por el empleador, puede ser elegible para Beneficios de Licencia Familiar Durante el Desempleo (FLDU). Esta es una combinación de los programas de Seguro por Desempleo y Seguro de Licencia Familiar.
 
         ** Próximos pasos sugeridos: **
 
@@ -424,14 +424,14 @@ sections:
         3. Create an account at [myunemployment.nj.gov](https://myunemployment.nj.gov/labor/myunemployment/before/createaccount/index.shtml).
         4. File an [application](https://myunemployment.nj.gov/) (online preferred).
       es: |-
-        Puede ser elegible para los beneficios regulares del seguro de desempleo. En la mayoría de los casos, no puede cobrar los beneficios del seguro de desempleo (UI) si se niega a [trabajo adecuado](https://www.nj.gov/labor/worker-protections/returntowork.shtml#suitable). Pueden ocurrir excepciones cuando un individuo renuncia o se niega a trabajar porque el trabajo representa un alto grado de riesgo para la salud y la seguridad y el empleado ha intentado remediar el problema con el empleador. NJDOL examina los casos de forma individual y determina la elegibilidad de acuerdo con la ley.
+        Puede ser elegible para los beneficios regulares del Seguro de Desempleo. En la mayoría de los casos, no puede cobrar los beneficios del seguro de desempleo (UI) si rechaza un [trabajo adecuado](https://www.nj.gov/labor/worker-protections/returntowork.shtml#suitable). Pueden ocurrir excepciones cuando un individuo renuncia o se niega a trabajar porque el trabajo representa un alto grado de riesgo para la salud y la seguridad y el empleado ha intentado remediar el problema con el empleador. NJDOL examina los casos de forma individual y determina la elegibilidad de acuerdo con la ley.
 
         ** Próximos pasos sugeridos: **
 
-        1. Obtenga más información sobre cómo regresar al trabajo en medio de COVID-19 [aquí](https://www.nj.gov/labor/worker-protections/returntowork.shtml)
-        2. Aprenda [cómo solicitar](https://myunemployment.nj.gov/labor/myunemployment/before/about/howtoapply/) para el desempleo.
-        3. Cree una cuenta en [myunemployment.nj.gov] (https://myunemployment.nj.gov/labor/myunemployment/before/createaccount/index.shtml).
-        4. Presente una [solicitud] (https://myunemployment.nj.gov/) (preferiblemente en línea).
+        1. Obtenga más información sobre el regreso al trabajo en medio de COVID-19 [aquí](https://www.nj.gov/labor/worker-protections/returntowork.shtml)
+        2. Aprenda [cómo solicitar](https://myunemployment.nj.gov/labor/myunemployment/before/about/howtoapply/) los beneficios del desempleo.
+        3. Abra una cuenta en [myunemployment.nj.gov] (https://myunemployment.nj.gov/labor/myunemployment/before/createaccount/index.shtml).
+        4. Presentar una [solicitud] (https://myunemployment.nj.gov/) (preferiblemente en línea).
 pages:
   - title:
       en: Introduction
@@ -831,7 +831,7 @@ definitions:
             color: '#ACD6B2'
         - name:
             en: 'My workplace is unsafe, my employer refuses to follow health and safety guidelines, and I refuse to work.'
-            es: 'Mi lugar de trabajo no es seguro, mi empleador se niega a seguir las pautas de salud y seguridad y yo me niego a trabajar.'
+            es: 'Mi lugar de trabajo no está seguro, mi empleador se niega a seguir las directrices de salud y seguridad y yo me niego a trabajar.'
           id: situation-12
           benefits: 'ESL-NJ,UI-NJ'
           icon:
@@ -839,7 +839,7 @@ definitions:
             color: '#FFB6C1'
         - name:
             en: 'I have been receiving unemployment benefits but I am no longer able to work due to my own non-work-related medical condition, including pregnancy and delivery.'
-            es: 'He estado recibiendo beneficios por desempleo pero ya no puedo trabajar debido a mi propia afección médica no relacionada con el trabajo, incluidos el embarazo y el parto.'
+            es: 'Estoy recibiendo beneficios por desempleo, pero ya no puedo trabajar debido a mi propia condición médica que no es relacionada con el trabajo, incluidos el embarazo y el parto.'
           id: situation-13
           benefits: DDU-NJ
           icon:
@@ -847,7 +847,7 @@ definitions:
             color: '#BF7F58'
         - name:
             en: 'I have been receiving unemployment benefits but I am no longer available for work because I am bonding with a new child or providing care for an ill or injured loved one.'
-            es: 'He estado recibiendo beneficios por desempleo, pero ya no estoy disponible para trabajar porque estoy creando un vínculo afectivo con un nuevo hijo o brindando atención a un ser querido enfermo o lesionado.'
+            es: 'He estado recibiendo beneficios por desempleo, pero ya no estoy disponible para trabajar porque estoy estableciendo un vínculo fuerte con un hijo nuevo o cuidando a un ser querido enfermo o lesionado.'
           id: situation-14
           benefits: FLDU-NJ
           icon:

--- a/public/form.yml
+++ b/public/form.yml
@@ -415,7 +415,7 @@ sections:
       es: Seguro de desempleo (UI)
     content:
       en: |-
-        You may be eligible for regular Unemployment Insurance benefits. In most cases, you cannot collect Unemployment Insurance (UI) benefits if you refuse [suitable work](https://www.nj.gov/labor/worker-protections/returntowork.shtml). Exceptions could occur where an individual quits or refuses work because the work poses a high degree of risk to health and safety. NJDOL examines cases on an individual basis, and makes eligibility determinations in accordance with the law.
+        You may be eligible for regular Unemployment Insurance benefits. In most cases, you cannot collect Unemployment Insurance (UI) benefits if you refuse [suitable work](https://www.nj.gov/labor/worker-protections/returntowork.shtml#suitable). Exceptions could occur where an individual quits or refuses work because the work poses a high degree of risk to health and safety and the employee has attempted to remedy the problem with the employer. NJDOL examines cases on an individual basis, and makes eligibility determinations in accordance with the law.
 
         **Suggested next steps:**
 
@@ -424,7 +424,7 @@ sections:
         3. Create an account at [myunemployment.nj.gov](https://myunemployment.nj.gov/labor/myunemployment/before/createaccount/index.shtml).
         4. File an [application](https://myunemployment.nj.gov/) (online preferred).
       es: |-
-        Puede ser elegible para los beneficios regulares del seguro de desempleo. En la mayoría de los casos, no puede cobrar los beneficios del seguro de desempleo (UI) si se niega a [trabajo adecuado](https://www.nj.gov/labor/worker-protections/returntowork.shtml). Pueden ocurrir excepciones cuando una persona renuncia o se niega a trabajar porque el trabajo presenta un alto grado de riesgo para la salud y la seguridad. NJDOL examina los casos de forma individual y determina la elegibilidad de acuerdo con la ley.
+        Puede ser elegible para los beneficios regulares del seguro de desempleo. En la mayoría de los casos, no puede cobrar los beneficios del seguro de desempleo (UI) si se niega a [trabajo adecuado](https://www.nj.gov/labor/worker-protections/returntowork.shtml#suitable). Pueden ocurrir excepciones cuando un individuo renuncia o se niega a trabajar porque el trabajo representa un alto grado de riesgo para la salud y la seguridad y el empleado ha intentado remediar el problema con el empleador. NJDOL examina los casos de forma individual y determina la elegibilidad de acuerdo con la ley.
 
         ** Próximos pasos sugeridos: **
 
@@ -825,7 +825,7 @@ definitions:
             es: |-
               A mi empleador se le ordenó cerrar, pero se quedó abierto. Tengo miedo a la exposición a COVID-19 y me niego a trabajar.
           id: situation-9
-          benefits: ESL-NJ
+          benefits: 'ESL-NJ,UI-NJ'
           icon:
             label: J
             color: '#ACD6B2'
@@ -833,7 +833,7 @@ definitions:
             en: 'My workplace is unsafe, my employer refuses to follow health and safety guidelines, and I refuse to work.'
             es: 'Mi lugar de trabajo no es seguro, mi empleador se niega a seguir las pautas de salud y seguridad y yo me niego a trabajar.'
           id: situation-12
-          benefits: UI-NJ
+          benefits: 'ESL-NJ,UI-NJ'
           icon:
             label: K
             color: '#FFB6C1'

--- a/public/form.yml
+++ b/public/form.yml
@@ -452,7 +452,10 @@ pages:
         - NJ Earned Sick Leave (ESL)
         - NJ Family Leave Insurance (FLI)
         - NJ Temporary Disability Insurance (TDI)
-        - Unemployment Assistance
+        - NJ Family Leave During Unemployment (NJFLDU)
+        - NJ Disability During Unemployment (NJDDU)
+        - Unemployment Insurance (UI)
+        - Unemployment Assistance (CARES Act)
         - Federal Pandemic Unemployment Compensation (FPUC)
         - Pandemic Emergency Unemployment Compensation (PEUC)
         - Pandemic Unemployment Assistance (PUA)
@@ -858,7 +861,7 @@ definitions:
             es: |-
               Ninguna de las declaraciones anteriores describe la situación mia. Me gustaría saber más sobre todos los beneficios.
           id: situation-10
-          benefits: 'UA,EPSL-FED,ESL-NJ,FLI-NJ,TDI-NJ,FEC-FMLA-FED,DDU-NJ,FLDU-NJ,UI-NJ'
+          benefits: 'ESL-NJ,FLI-NJ,TDI-NJ,FLDU-NJ,DDU-NJ,UI-NJ,UA,FPUC-FED,PEUC-FED,EPSL-FED,FEC-FMLA-FED'
           job-protections: 'A3848,FMLA-FED,FLA-NJ'
           icon:
             label: N

--- a/public/form.yml
+++ b/public/form.yml
@@ -39,7 +39,7 @@ instructions:
     es: Descargar
   clear-form:
     en: Clear Form
-    es: Forma clara
+    es: Borra las selecciones
   submit-instructions:
     en: |-
       Please review and verify the information section below. If there are errors in any section, you may select 'Edit' to revisit that page of your application.
@@ -297,7 +297,7 @@ sections:
   FEC-FMLA-FED:
     title:
       en: Federal Emergency Childcare FMLA
-      es: Federal Emergency Childcare FMLA
+      es: Ley federal de emergencia – FMLA licencia por Cuidar Hijos
     content:
       en: |-
         You may be eligible for up to 12 weeks of job-protected leave, 10 paid by your employer. Federal Emergency Childcare FMLA gives certain workers access to emergency paid leave to care for their children at home, due to COVID-19.

--- a/public/form.yml
+++ b/public/form.yml
@@ -487,7 +487,10 @@ pages:
         - Licencia por enfermedad pagada de New Jersey (ESL)
         - Seguro de licencia familiar de NJ (FLI)
         - Seguro de incapacidad temporal de NJ (TDI)
-        - Asistencia de desempleo
+        - Licencia Familiar de New Jersey Durante el Desempleo (NJFLDU)
+        - Seguro de Incapacidad de New Jersey Durante el Desempleo (NJDDU)
+        - Seguro de desempleo (UI)
+        - Asistencia de desempleo (CARES Act)
         - Compensación federal de desempleo pandémico (FPUC)
         - Compensación de emergencia por desempleo pandémico (PEUC)
         - Asistencia de desempleo pandémico (PUA)

--- a/public/form.yml
+++ b/public/form.yml
@@ -292,7 +292,7 @@ sections:
 
         ** Próximos pasos sugeridos: **
 
-        1. Obtenga más información: Descripción general: [Licencia por enfermedad pagada de emergencia y ampliada ley de licencia médica y familiar](https://www.nj.gov/labor/assets/PDFs/FamiliesFirstCoronaResAct.pdf)
+        1. Obtenga más información: Descripción general: [Licencia por enfermedad pagada de emergencia y ampliada ley de licencia médica y familiar](https://nj.gov/labor/assets/PDFs/FamiliesFirstCoronaResAct%20Spanish%204%2022%2020.pdf)
         2. Hable con su empleador sobre su derecho a utilizar este permiso
   FEC-FMLA-FED:
     title:
@@ -311,7 +311,7 @@ sections:
 
         ** Próximos pasos sugeridos **
 
-        1. Obtenga más información: [Ley de respuesta al coronavirus de Families First](https://www.nj.gov/labor/assets/PDFs/FamiliesFirstCoronaResAct.pdf)
+        1. Obtenga más información: [Ley de respuesta al coronavirus de Families First](https://nj.gov/labor/assets/PDFs/FamiliesFirstCoronaResAct%20Spanish%204%2022%2020.pdf)
         2. Hable con su empleador sobre su derecho a utilizar este permiso
   A3848:
     title:
@@ -430,8 +430,8 @@ sections:
 
         1. Obtenga más información sobre el regreso al trabajo en medio de COVID-19 [aquí](https://www.nj.gov/labor/worker-protections/returntowork.shtml)
         2. Aprenda [cómo solicitar](https://myunemployment.nj.gov/labor/myunemployment/before/about/howtoapply/) los beneficios del desempleo.
-        3. Abra una cuenta en [myunemployment.nj.gov] (https://myunemployment.nj.gov/labor/myunemployment/before/createaccount/index.shtml).
-        4. Presentar una [solicitud] (https://myunemployment.nj.gov/) (preferiblemente en línea).
+        3. Abra una cuenta en [myunemployment.nj.gov](https://myunemployment.nj.gov/labor/myunemployment/before/createaccount/index.shtml).
+        4. Presentar una [solicitud](https://myunemployment.nj.gov/) (preferiblemente en línea).
 pages:
   - title:
       en: Introduction
@@ -858,7 +858,7 @@ definitions:
             es: |-
               Ninguna de las declaraciones anteriores describe la situación mia. Me gustaría saber más sobre todos los beneficios.
           id: situation-10
-          benefits: 'UA,EPSL-FED,ESL-NJ,FLI-NJ,TDI-NJ,FEC-FMLA-FED'
+          benefits: 'UA,EPSL-FED,ESL-NJ,FLI-NJ,TDI-NJ,FEC-FMLA-FED,DDU-NJ,FLDU-NJ,UI-NJ'
           job-protections: 'A3848,FMLA-FED,FLA-NJ'
           icon:
             label: N

--- a/public/form.yml
+++ b/public/form.yml
@@ -375,6 +375,40 @@ sections:
         1. Obtenga más información: [NJ Family Leave Act](https://www.nj.gov/oag/dcr/downloads/fact-FLA.pdf)
         2. Hable con su empleador sobre su situación de protección laboral
         3. Si no cumplen, [presente una queja](https://www.nj.gov/oag/dcr/filing.html)
+  DDU-NJ:
+    title:
+      en: New Jersey Disability During Unemployment (NJDDU)
+      es: Discapacidad de Nueva Jersey durante el desempleo (NJDDU)
+    content:
+      en: |-
+        If your medical provider certifies you are unable to work due to your own non-work-related medical condition, including pregnancy and delivery, more than 14 days after your last day of work in covered employment, you may be eligible for Disability During Unemployment (DDU) benefits. This is a combination of the Unemployment and Temporary Disability Insurance programs.
+
+        **Suggested next steps:**
+
+        1. Get more information and learn how to apply [here](https://myleavebenefits.nj.gov/unemployed).
+      es: |-
+        Si su proveedor médico certifica que no puede trabajar debido a su propia afección médica no relacionada con el trabajo, incluidos el embarazo y el parto, más de 14 días después de su último día de trabajo en un empleo cubierto, es posible que sea elegible para la discapacidad durante el desempleo (DDU) beneficios. Esta es una combinación de los programas de seguro de desempleo y por discapacidad temporal.
+
+        ** Próximos pasos sugeridos: **
+
+        1. Obtenga más información y aprenda cómo postularse [aquí](https://myleavebenefits.nj.gov/unemployed).
+  FLDU-NJ:
+    title:
+      en: New Jersey Family Leave During Unemployment (NJFLDU)
+      es: Permiso familiar de Nueva Jersey durante el desempleo (NJFLDU)
+    content:
+      en: |-
+        If you need to bond with a new child or care for an ill or injured loved one more than 14 days after your last day of work in covered employment, and are not on an employer-approved leave of absence, you may be eligible for Family Leave During Unemployment (FLDU) benefits. This is a combination of the Unemployment and Family Leave Insurance programs.
+
+        **Suggested next steps:**
+
+        1. Get more information and learn how to apply [here](https://myleavebenefits.nj.gov/unemployed).
+      es: |-
+        Si necesita vincularse con un nuevo hijo o cuidar a un ser querido enfermo o lesionado más de 14 días después de su último día de trabajo en un empleo cubierto, y no está en una licencia de ausencia aprobada por el empleador, puede ser elegible para Beneficios de licencia durante el desempleo (FLDU). Esta es una combinación de los programas de seguro por desempleo y permiso familiar.
+
+        ** Próximos pasos sugeridos: **
+
+        1. Obtenga más información y aprenda cómo postularse [aquí](https://myleavebenefits.nj.gov/unemployed).
 pages:
   - title:
       en: Introduction
@@ -628,6 +662,16 @@ pages:
                       es: |-
                         Según la información que proporcionó, puede ser elegible para recibir protección o ayuda financiera de estos programas:
                   - type: sections
+                    id: terminal-eligibility-3
+                    sections:
+                      name:
+                        en: Benefits
+                        es: Beneficios
+                      include:
+                        - DDU-NJ
+                        - FLDU-NJ
+                      color: '#F6F7F9'
+                  - type: sections
                     id: terminal-eligibility-2
                     sections:
                       name:
@@ -636,7 +680,7 @@ pages:
                       include:
                         - PEUC-FED
                         - FPUC-FED
-                      color: '#F6F7F9'
+                      color: '#ECEEF1'
           'works-in-another-state,laid-off-in-another-state':
             - name:
                 en: Eligibility
@@ -763,6 +807,30 @@ definitions:
             label: J
             color: '#ACD6B2'
         - name:
+            en: 'My workplace is unsafe, my employer refuses to follow health and safety guidelines, and I refuse to work.'
+            es: 'Mi lugar de trabajo no es seguro, mi empleador se niega a seguir las pautas de salud y seguridad y yo me niego a trabajar.'
+          id: situation-12
+          benefits: UA
+          icon:
+            label: K
+            color: '#FFB6C1'
+        - name:
+            en: 'I have been receiving unemployment benefits but I am no longer able to work due to my own non-work-related medical condition, including pregnancy and delivery.'
+            es: 'He estado recibiendo beneficios por desempleo pero ya no puedo trabajar debido a mi propia afección médica no relacionada con el trabajo, incluidos el embarazo y el parto.'
+          id: situation-13
+          benefits: DDU-NJ
+          icon:
+            label: L
+            color: '#BF7F58'
+        - name:
+            en: 'I have been receiving unemployment benefits but I am no longer available for work because I am bonding with a new child or providing care for an ill or injured loved one.'
+            es: 'He estado recibiendo beneficios por desempleo, pero ya no estoy disponible para trabajar porque estoy creando un vínculo afectivo con un nuevo hijo o brindando atención a un ser querido enfermo o lesionado.'
+          id: situation-14
+          benefits: FLDU-NJ
+          icon:
+            label: M
+            color: '#C72263'
+        - name:
             en: None of the above statements describe my situation. I would like to know more about all program benefits.
             es: |-
               Ninguna de las declaraciones anteriores describe la situación mia. Me gustaría saber más sobre todos los beneficios.
@@ -770,10 +838,10 @@ definitions:
           benefits: 'UA,EPSL-FED,ESL-NJ,FLI-NJ,TDI-NJ,FEC-FMLA-FED'
           job-protections: 'A3848,FMLA-FED,FLA-NJ'
           icon:
-            label: K
+            label: N
             color: lightgrey
       switch:
-        ? 'situation-1,situation-2,situation-3,situation-4,situation-5,situation-6,situation-7,situation-8,situation-9,situation-11'
+        ? 'situation-1,situation-2,situation-3,situation-4,situation-5,situation-6,situation-7,situation-8,situation-9,situation-11,situation-12,situation-13,situation-14'
         : - name:
               en: You may be eligible for...
               es: Puede ser elegible para ...


### PR DESCRIPTION
scope:
 - The 3 new options for the 3A-K options list have been added, and their resulting benefits.
- FLDU/TDDU: Both Logics 1 and 2 are done - though with no conditionality for Logic 1. (Logic 2 doesn't need conditionality - it's done.) In other words, new options L and M will always appear in the long 3A-N list. 
- Return to Work: Logic 2 is done, except for conditionality, if needed (I'm not sure if it is or not). The new Option K is there (always), but he also made the NJESL appear for K, and the new UI appear for J, as specified. Logic 1: Added option K and its benefit (always), that's it. No PUA stuff, yet, and no conditionality.
- Includes the Spanish copy for FLDU/TDDU and Return to Work, and the "in covered employment" copy fix.
- 4 Spanish fixes from the 9/21 launch (except that the “FamiliesFirstCoronaResAct Spanish” PDF is not up, yet, so Issue 3 parts 1 and 2 cannot be done, only part 3).